### PR TITLE
add support for single table input in eav_attribute_value

### DIFF
--- a/src/admin/assets/formbuilder/js/formbuilder.js
+++ b/src/admin/assets/formbuilder/js/formbuilder.js
@@ -1069,7 +1069,7 @@
 
 						__p += '<div class="fb-edit-section-header"> ' + Formbuilder.lang('Field type:') + ' ' +
 								((__t = ( rf.get(Formbuilder.names.FIELD_TYPE) )) == null ? '' : Formbuilder.lang(__t)) +
-								', Attribure id: ' + rf.cid + '</div><div class="fb-common-wrapper"><div class="fb-label-description">' +
+								', Attribute id: ' + rf.cid + '</div><div class="fb-common-wrapper"><div class="fb-label-description">' +
 								((__t = ( Formbuilder.templates['edit/label_description']() )) == null ? '' : __t) +
 								'</div><div class="fb-common-checkboxes">';
 				}

--- a/src/handlers/ValueHandler.php
+++ b/src/handlers/ValueHandler.php
@@ -10,58 +10,67 @@ use yii\db\ActiveRecord;
 
 /**
  * Class ValueHandler
- *
  * @package mirocow\eav
+ *
  * @property ActiveRecord $valueModel
  * @property string $textValue
  */
 abstract class ValueHandler
 {
-    const STORE_TYPE_RAW = 0;
-    const STORE_TYPE_OPTION = 1;
-    const STORE_TYPE_MULTIPLE_OPTIONS = 2;
-    const STORE_TYPE_ARRAY = 3; // Json encoded
+        const STORE_TYPE_RAW = 0;
+        const STORE_TYPE_OPTION = 1;
+        const STORE_TYPE_MULTIPLE_OPTIONS = 2;
+        const STORE_TYPE_ARRAY = 3; // Json encoded
 
-    /** @var AttributeHandler */
-    public $attributeHandler;
+        /** @var AttributeHandler */
+        public $attributeHandler;
 
-    /**
-     * @return ActiveRecord
-     * @throws \Exception
-     * @throws \yii\base\InvalidConfigException
-     */
-    public function getValueModel()
-    {
-        $EavModel = $this->attributeHandler->owner;
+        /**
+         * @return ActiveRecord
+         * @throws \Exception
+         * @throws \yii\base\InvalidConfigException
+         */
+        public function getValueModel()
+        {
+                $EavModel = $this->attributeHandler->owner;
 
-        /** @var ActiveRecord $valueClass */
-        $valueClass = $EavModel->valueClass;
+                /** @var ActiveRecord $valueClass */
+                $valueClass = $EavModel->valueClass;
+                $entityId = $EavModel->entityModel->getPrimaryKey();
+                $attributeId = $this->attributeHandler->attributeModel->getPrimaryKey();
+                $valueId = $EavModel->entityModel->valueId;
 
-        $valueModel = $valueClass::findOne(
-            [
-                'entityId' => $EavModel->entityModel->getPrimaryKey(),
-                'attributeId' => $this->attributeHandler->attributeModel->getPrimaryKey(),
-            ]
-        );
+                if($EavModel->entityModel->isUpdate){
+                    $valueModel = $valueClass::findOne([
+                        'entityId' => $entityId,
+                        'attributeId' => $attributeId,
+                        'valueId' => $valueId
+                    ]);
+                }else{
+                    $valueModel = new $valueClass;
+                    $valueModel->entityId = $entityId;
+                    $valueModel->attributeId = $attributeId;
+                    $valueModel->valueId = $valueId;
+                }
+                
+                if (!$valueModel instanceof ActiveRecord) {
+                        /** @var ActiveRecord $valueModel */
+                        $valueModel = new $valueClass;
+                        $valueModel->entityId = $entityId;
+                        $valueModel->attributeId = $attributeId;
+                }
 
-        if (!$valueModel instanceof ActiveRecord) {
-            /** @var ActiveRecord $valueModel */
-            $valueModel = new $valueClass;
-            $valueModel->entityId = $EavModel->entityModel->getPrimaryKey();
-            $valueModel->attributeId = $this->attributeHandler->attributeModel->getPrimaryKey();
+                return $valueModel;
         }
 
-        return $valueModel;
-    }
+        abstract public function defaultValue();
 
-    abstract public function defaultValue();
+        abstract public function load();
 
-    abstract public function load();
+        abstract public function save();
 
-    abstract public function save();
+        abstract public function getTextValue();
 
-    abstract public function getTextValue();
-
-    // TODO 7: Add rules from $attributeModel->getEavOptions()
-    abstract public function addRules();
+        // TODO 7: Add rules from $attributeModel->getEavOptions()
+        abstract public function addRules();
 }

--- a/src/migrations/m150821_133232_init.php
+++ b/src/migrations/m150821_133232_init.php
@@ -58,129 +58,69 @@ class m150821_133232_init extends Migration
             ? 'CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE=InnoDB'
             : null;
 
-        $this->createTable(
-            $this->tables['entity'],
-            [
-                'id' => $this->primaryKey(11),
-                'entityName' => $this->string(50),
-                'entityModel' => $this->string(100),
-                'categoryId' => $this->integer(11),
-            ],
-            $options
-        );
+        $this->createTable($this->tables['entity'], [
+            'id' => $this->primaryKey(11),
+            'entityName' => $this->string(50),
+            'entityModel' => $this->string(100),
+            'categoryId' => $this->integer(11),
+        ], $options);
 
-        $this->createTable(
-            $this->tables['attribute'],
-            [
-                'id' => $this->primaryKey(11),
-                'entityId' => $this->integer(11)->defaultValue(null),
-                'typeId' => $this->integer(11)->defaultValue(null),
-                'type' => $this->string(50)->defaultValue(''),
-                'name' => $this->string(255)->defaultValue('NULL'),
-                'label' => $this->string(255)->defaultValue('NULL'),
-                'defaultValue' => $this->string(255)->defaultValue('NULL'),
-                'defaultOptionId' => $this->integer(11)->defaultValue(0),
-                'description' => $this->string(255)->defaultValue('NULL'),
-                'required' => $this->smallInteger(1)->defaultValue(0),
-                'order' => $this->integer(11)->defaultValue(0),
-            ],
-            $options
-        );
+        $this->createTable($this->tables['attribute'], [
+            'id' => $this->primaryKey(11),
+            'entityId' => $this->integer(11)->defaultValue(NULL),
+            'typeId' => $this->integer(11)->defaultValue(NULL),
+            'type' => $this->string(50)->defaultValue(''),
+            'name' => $this->string(255)->defaultValue('NULL'),
+            'label' => $this->string(255)->defaultValue('NULL'),
+            'defaultValue' => $this->string(255)->defaultValue('NULL'),
+            'defaultOptionId' => $this->integer(11)->defaultValue(0),
+            'description' => $this->string(255)->defaultValue('NULL'),
+            'required' => $this->smallInteger(1)->defaultValue(0),
+            'order' => $this->integer(11)->defaultValue(0),
+        ], $options);
 
-        $this->createTable(
-            $this->tables['attribute_type'],
-            [
-                'id' => $this->primaryKey(11),
-                'name' => $this->string(255)->defaultValue('NULL'),
-                'handlerClass' => $this->string(255)->defaultValue('NULL'),
-                'storeType' => $this->smallInteger(6)->defaultValue(0),
-            ],
-            $options
-        );
+        $this->createTable($this->tables['attribute_type'], [
+            'id' => $this->primaryKey(11),
+            'name' => $this->string(255)->defaultValue('NULL'),
+            'handlerClass' => $this->string(255)->defaultValue('NULL'),
+            'storeType' => $this->smallInteger(6)->defaultValue(0),
+        ], $options);
 
-        $this->createTable(
-            $this->tables['value'],
-            [
-                'id' => $this->primaryKey(11),
-                'entityId' => $this->integer(11)->defaultValue(0),
-                'attributeId' => $this->integer(11)->defaultValue(0),
-                'value' => $this->string(255)->defaultValue('NULL'),
-                'optionId' => $this->integer(11)->defaultValue(0),
-            ],
-            $options
-        );
+        $this->createTable($this->tables['value'], [
+            'id' => $this->primaryKey(11),
+            'entityId' => $this->integer(11)->defaultValue(0),
+            'attributeId' => $this->integer(11)->defaultValue(0),
+            'valueId' => $this->integer(11),
+            'value' => $this->string(255)->defaultValue('NULL'),
+            'optionId' => $this->integer(11)->defaultValue(0),
+        ], $options);
 
-        $this->createTable(
-            $this->tables['option'],
-            [
-                'id' => $this->primaryKey(11),
-                'attributeId' => $this->integer(11)->defaultValue(0),
-                'value' => $this->string(255)->defaultValue('NULL'),
-                'defaultOptionId' => $this->smallInteger(1)->defaultValue(0),
-            ],
-            $options
-        );
+        $this->createTable($this->tables['option'], [
+            'id' => $this->primaryKey(11),
+            'attributeId' => $this->integer(11)->defaultValue(0),
+            'value' => $this->string(255)->defaultValue('NULL'),
+            'defaultOptionId' => $this->smallInteger(1)->defaultValue(0),
+        ], $options);
 
         if ($this->db->driverName != "sqlite") {
-            $this->addForeignKey(
-                'FK_Attribute_typeId',
-                $this->tables['attribute'],
-                'typeId',
-                $this->tables['attribute_type'],
-                'id',
-                "CASCADE",
-                "NO ACTION"
-            );
 
-            $this->addForeignKey(
-                'FK_EntityId',
-                $this->tables['attribute'],
-                'entityId',
-                $this->tables['entity'],
-                'id',
-                "CASCADE",
-                "NO ACTION"
-            );
+            $this->addForeignKey('FK_Attribute_typeId',
+                $this->tables['attribute'], 'typeId', $this->tables['attribute_type'], 'id', "CASCADE", "NO ACTION");
 
-            $this->addForeignKey(
-                'FK_Value_entityId',
-                $this->tables['value'],
-                'entityId',
-                $this->tables['entity'],
-                'id',
-                "CASCADE",
-                "NO ACTION"
-            );
+            $this->addForeignKey('FK_EntityId',
+                $this->tables['attribute'], 'entityId', $this->tables['entity'], 'id', "CASCADE", "NO ACTION");
 
-            $this->addForeignKey(
-                'FK_Value_attributeId',
-                $this->tables['value'],
-                'attributeId',
-                $this->tables['attribute'],
-                'id',
-                "CASCADE",
-                "NO ACTION"
-            );
+            $this->addForeignKey('FK_Value_entityId',
+                $this->tables['value'], 'entityId', $this->tables['entity'], 'id', "CASCADE", "NO ACTION");
 
-            $this->addForeignKey(
-                'FK_Value_optionId',
-                $this->tables['value'],
-                'optionId',
-                $this->tables['option'],
-                'id',
-                "CASCADE",
-                "NO ACTION"
-            );
+            $this->addForeignKey('FK_Value_attributeId',
+                $this->tables['value'], 'attributeId', $this->tables['attribute'], 'id', "CASCADE", "NO ACTION");
 
-            $this->addForeignKey(
-                'FK_Option_attributeId',
-                $this->tables['option'],
-                'attributeId',
-                $this->tables['attribute'],
-                'id',
-                "CASCADE",
-                "NO ACTION"
-            );
+            $this->addForeignKey('FK_Value_optionId',
+                $this->tables['value'], 'optionId', $this->tables['option'], 'id', "CASCADE", "NO ACTION");
+
+            $this->addForeignKey('FK_Option_attributeId',
+                $this->tables['option'], 'attributeId', $this->tables['attribute'], 'id', "CASCADE", "NO ACTION");
         }
 
         foreach ($this->attributeTypes as $columns) {

--- a/src/models/EavAttributeValue.php
+++ b/src/models/EavAttributeValue.php
@@ -11,8 +11,10 @@ use Yii;
  * @property integer $id
  * @property integer $entityId
  * @property integer $attributeId
+ * @property integer $valueId
  * @property string $value
  * @property integer $optionId
+ *
  * @property EavAttribute $attribute
  * @property Eav $entity
  * @property EavAttributeOption $option
@@ -28,14 +30,23 @@ class EavAttributeValue extends \yii\db\ActiveRecord
     }
 
     /**
+     * Auto increment function for value ID
+     *
+     * @return int
+     */
+    public static function getLastValueId($entityId){
+        return static::find(['entityId' => $entityId])->max('valueId');
+    }
+
+    /**
      * @inheritdoc
      */
     public function rules()
     {
         return [
             [['entityId', 'attributeId'], 'required'],
-            [['entityId', 'attributeId', 'optionId'], 'integer'],
-            [['value'], 'string', 'max' => 1023],
+            [['entityId', 'attributeId', 'valueId', 'optionId'], 'integer'],
+            [['value'], 'string', 'max' => 255],
         ];
     }
 
@@ -48,6 +59,7 @@ class EavAttributeValue extends \yii\db\ActiveRecord
             'id' => 'ID',
             'entityId' => Yii::t('eav', 'Entity ID'),
             'attributeId' => Yii::t('eav', 'Attribute ID'),
+            'valueId' => Yii::t('eav', 'Value ID'),
             'value' => Yii::t('eav', 'Value'),
             'optionId' => Yii::t('eav', 'Option ID'),
         ];

--- a/src/models/EavAttributeValueSearch.php
+++ b/src/models/EavAttributeValueSearch.php
@@ -17,7 +17,7 @@ class EavAttributeValueSearch extends EavAttributeValue
     public function rules()
     {
         return [
-            [['id', 'entityId', 'attributeId', 'optionId'], 'integer'],
+            [['id', 'entityId', 'attributeId', 'valueId', 'optionId'], 'integer'],
             [['value'], 'safe'],
         ];
     }
@@ -35,6 +35,7 @@ class EavAttributeValueSearch extends EavAttributeValue
      * Creates data provider instance with search query applied
      *
      * @param array $params
+     *
      * @return ActiveDataProvider
      */
     public function search($params)
@@ -43,11 +44,9 @@ class EavAttributeValueSearch extends EavAttributeValue
 
         // add conditions that should always apply here
 
-        $dataProvider = new ActiveDataProvider(
-            [
-                'query' => $query,
-            ]
-        );
+        $dataProvider = new ActiveDataProvider([
+            'query' => $query,
+        ]);
 
         $this->load($params);
 
@@ -58,14 +57,13 @@ class EavAttributeValueSearch extends EavAttributeValue
         }
 
         // grid filtering conditions
-        $query->andFilterWhere(
-            [
-                'id' => $this->id,
-                'entityId' => $this->entityId,
-                'attributeId' => $this->attributeId,
-                'optionId' => $this->optionId,
-            ]
-        );
+        $query->andFilterWhere([
+            'id' => $this->id,
+            'entityId' => $this->entityId,
+            'attributeId' => $this->attributeId,
+            'valueId' => $this->valueId,
+            'optionId' => $this->optionId,
+        ]);
 
         $query->andFilterWhere(['like', 'value', $this->value]);
 

--- a/src/models/EavEntity.php
+++ b/src/models/EavEntity.php
@@ -10,10 +10,14 @@ use Yii;
  * @property integer $id
  * @property string $entityName
  * @property string $entityModel
+ *
  * @property EavAttribute[] $eavAttributes
  */
 class EavEntity extends \yii\db\ActiveRecord
 {
+    public bool $isUpdate = true;
+    public int $valueId;
+
     /**
      * @inheritdoc
      */
@@ -44,7 +48,7 @@ class EavEntity extends \yii\db\ActiveRecord
             'entityName' => Yii::t('eav', 'Entity name'),
             'entityModel' => Yii::t('eav', 'Entity Model'),
             'categoryId' => Yii::t('eav', 'ID Category'),
-            'modelId' => Yii::t('eav', 'ID Model'),
+            'modelId' => Yii::t('eav', 'ID Model')
         ];
     }
 
@@ -55,5 +59,50 @@ class EavEntity extends \yii\db\ActiveRecord
     {
         return $this->hasMany(EavAttribute::className(), ['entityId' => 'id'])
             ->orderBy(['order' => SORT_DESC]);
+    }
+
+    public function viewModelAttributes(){
+        foreach($this->getEavAttributes()->all() as $key => $attr){
+            $attributes[] = [
+                'label' => $attr->label,
+                'value' => $this::getValue($this, $attr, $key)
+            ];
+        }
+
+        return $attributes;
+    }
+
+    public static function getValue(EavEntity $model, EavAttribute $attr, int $key){
+        $value = $model[$attr->name];
+        if($attr->typeId == 2){
+            $value = $attr->eavAttributeValues[$key]->option->value;
+            return $value;
+        }
+        if($value instanceof \mirocow\eav\EavModel){
+            $value = $model[$attr->name]->value;
+            return $value;
+        }
+        return $value;
+    }
+
+    public static function getModelAttributes(EavEntity $model){
+        foreach ($model->getEavAttributes()->all() as $key => $attr) {
+            $attributes[$attr->label] = $model::getValue($model, $attr, $key);
+        }
+        
+        return $attributes;
+    }
+
+    public static function getValueList($entityId){
+        $modelList = [];
+        $ids = EavAttributeValue::find()->select(['valueId'])->where(['entityId' => $entityId])->distinct()->all();
+        
+        foreach ($ids as $id) {
+            $model = static::findOne(['entityModel' => self::className()]);
+            $model->valueId = $id->valueId;
+            $modelList[] = static::getModelAttributes($model);
+        }
+
+        return $modelList;
     }
 }


### PR DESCRIPTION
formbuilder.js
- fix typo attribure -> attribute

migrations init.php
- add valueId to eav_attribute_values

EavAttributeValue, EavAttributeValueSearch, ValueHandler.php, EavEntity
- add valueId

EavEntity
- add isUpdate & valueId property
- add viewModelAttributes, getValuie, getrModelAttributes, getValueList functions